### PR TITLE
Adicionando arquivo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Senhas
+foto.png


### PR DESCRIPTION
Adicionado gitignore para evitar que os arquivos Senhas e foto.png subam para o controle de versão.